### PR TITLE
Prototype conflict

### DIFF
--- a/treeTable/src/javascripts/jquery.treeTable.js
+++ b/treeTable/src/javascripts/jquery.treeTable.js
@@ -211,6 +211,7 @@
     var classNames = node[0].className.split(' ');
     
     for(key in classNames) {
+      if (!key.match(/^[0-9]+$/)) { continue; }
       if(classNames[key].match(options.childPrefix)) {
         return $("#" + classNames[key].substring(9));
       }


### PR DESCRIPTION
I'm using your plugin in my redmine plugin; redmine ships with
prototype. It looks like prototype adds methods to the standard array
object, and even while 'console.log("classNames=%o", classNames);'
yields a normal-looking array, iterating through the keys gives you
all the extra cruft.
