### PR TITLE
Fixes from Drupal token module

### DIFF
--- a/treeTable/CHANGELOG
+++ b/treeTable/CHANGELOG
@@ -1,4 +1,5 @@
 == Unreleased
+* Fixed parentOf() did not use options.childPrefix.
 * Fixed problems with multiple treeTables with identical rows on the same page.
 * Fixed #8, #11, #14
 

--- a/treeTable/src/javascripts/jquery.treeTable.js
+++ b/treeTable/src/javascripts/jquery.treeTable.js
@@ -217,7 +217,7 @@
 
     for(var key=0; key<classNames.length; key++) {
       if(classNames[key].match(options.childPrefix)) {
-        return $(node).siblings("#" + classNames[key].substring(9));
+        return $(node).siblings("#" + classNames[key].substring(options.childPrefix.length));
       }
     }
 


### PR DESCRIPTION
We've found a few bugs from use in http://drupal.org/project/token:
- When you have multiple similar treeTables (same ID and/or CSS classes for table row) on the same page, clicking expand or collapse in one treeTable, performs the same expand/collapse for all rows with the same ID/classes. This can be fixed by use of $(node).closest() to restrict searches to the 'current' node's treeTable.
- The parentOf() function currently hard-codes the start position of substring() when it should be based off the length of options.childPrefix.

I did not yet updated the minified JS since that's likely left for a 'new' release version, but I did update the changelog.
