### PR TITLE
onNodeHide callback implementation

### DIFF
--- a/src/javascripts/jquery.treeTable.js
+++ b/src/javascripts/jquery.treeTable.js
@@ -50,6 +50,7 @@
     indent: 19,
     initialState: "collapsed",
     onNodeShow: null,
+    onNodeHide: null,
     treeColumn: 0,
     persist: false,
     persistCookiePrefix: 'treeTable_'
@@ -65,6 +66,11 @@
       }
 
       $(this).addClass('ui-helper-hidden');
+      
+      if($.isFunction(options.onNodeHide)) {
+        options.onNodeHide.call();
+      }
+      
     });
 
     return this;


### PR DESCRIPTION
If you're persisting collapsed/expanded nodes to a DB then you'd need to do an AJAX call on a callback.  For this reason it's useful to have both. Sorry, used the GitHub inline editor to do this and haven't tested, but it seems s straightforward implementation.
