### PR TITLE
Saving state of nodes using Persist.js instead of cookie

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -243,13 +243,13 @@ $(document).ready(function()  {
       <td><tt>persist</tt></td>
       <td><tt>bool</tt></td>
       <td><tt>false</tt></td>
-      <td>Persist tree state in cookie (requires <a href="https://github.com/carhartl/jquery-cookie">jquery-cookie</a> plugin).</td>
+      <td>Persist tree state on client side (requires <a href="http://github.com/jeremydurham/persist-js">persist.js</a>).</td>
     </tr>
     <tr>
-      <td><tt>persistCookiePrefix</tt></td>
+      <td><tt>persistStoreName</tt></td>
       <td><tt>string</tt></td>
-      <td><tt>&quot;treeTable_&quot;</tt></td>
-      <td>Prefix used for cookie name when <tt>persist</tt> is true.</td>
+      <td><tt>&quot;treeTable&quot;</tt></td>
+      <td>Store name used when <tt>persist</tt> is true.</td>
     </tr>
     <tr>
       <td><tt>treeColumn</tt></td>


### PR DESCRIPTION
"Cookie is limited by the number of maximum number of cookies that can be saved by the browser. Older browsers typically limited the number of cookies to 20 per domain, although newer browsers have increased this limit to 50 cookies per domain."

So, if we have big tables new node state cookies overwrite old ones or other cookie (for examples session cookie).

We can use one cookie for list of expanded nodes (how you say here https://github.com/ludo/jquery-treetable/pull/19#issuecomment-1688349), but max size of all cookies from domain is 4 kb and this is not enough for large tables.

Persist.js allow to store more data using "non-Cookie mechanisms for saving client-side persistent data"
