### PR TITLE
Added support to set the initial state of individual rows

### DIFF
--- a/javascripts/src/jquery.treetable.js
+++ b/javascripts/src/jquery.treetable.js
@@ -132,10 +132,19 @@
         });
       }
 
-      if (settings.expandable === true && settings.initialState === "collapsed") {
-        this.collapse();
-      } else {
-        this.expand();
+      if (settings.expandable === true) {
+        var state = this.row.context.getAttribute('data-tt-initialState');
+
+        if(state)
+          this.row.context.removeAttribute('data-tt-initialState')
+        else
+          state = settings.initialState
+
+        if (state === "collapsed") {
+          this.collapse();
+        } else {
+          this.expand();
+        }
       }
 
       this.indenter[0].style.paddingLeft = "" + (this.level() * settings.indent) + "px";


### PR DESCRIPTION
From an API perspective, this is achieved adding a new
'data-tt-initialState' attribute with the desired initial state
("collapsed" or "expanded"). This attribute is later removed
automatically so it doesn't interfiere anymore with the regular working
of the plugin.
