### PR TITLE
Fix to loadBranch

### DIFF
--- a/javascripts/src/jquery.treetable.js
+++ b/javascripts/src/jquery.treetable.js
@@ -437,7 +437,11 @@
       if (node == null) { // Inserting new root nodes
         this.append(rows);
       } else if (node.children.length > 0) {
-        rows.insertAfter(node.children[node.children.length-1].row);
+    	  var current = node;
+    	  while (current.children.length > 0) {
+    		  current = current.children[current.children.length - 1];
+    	  }
+    	  rows.insertAfter(current.row);
       } else {
         rows.insertAfter(node.row);
       }


### PR DESCRIPTION
Hi Ludo

Thanks for the truly awesome jquery.treetable plugin!

While using it, I discovered what I think is a bug in loadBranch().  I fixed it with this small commit (at least, it's working for me now).

The problem occurs when you call loadBranch() to add subnodes to a node that has open subtrees.  Say have this tree:

```
* A
* B
   * BA
   * BB
     * BBA
     * BBB
* C
```

If I call loadBranch() with node B as the first argument, to add row "D", I expect this:

```
* A
* B
   * BA
   * BB
     * BBA
     * BBB
   * D <--- new row added here
* C
```

But I get this:

```
* A
* B
   * BA
   * BB
   * D   <--- new row added here
     * BBA
     * BBB
* C
```

Does that make sense?

Thanks again!

Kyle (github: quile)
