### PR TITLE
Do not show child nodes on expand of a hidden node

### DIFF
--- a/javascripts/src/jquery.treetable.js
+++ b/javascripts/src/jquery.treetable.js
@@ -69,7 +69,9 @@
       }
 
       this.row.removeClass("collapsed").addClass("expanded");
-      this._showChildren();
+      if ($(this.row).is(":visible")) {
+        this._showChildren();
+      }
       this.expander.attr("title", this.settings.stringCollapse);
 
       return this;
@@ -441,6 +443,10 @@
       var node = this.data("treetable").tree[id];
 
       if (node) {
+        if (!node.initialized) {
+          node._initialize();
+        }
+
         node.expand();
       } else {
         throw new Error("Unknown node '" + id + "'");

--- a/javascripts/test/jquery.treetable.test.js
+++ b/javascripts/test/jquery.treetable.test.js
@@ -234,6 +234,7 @@
     describe("expandNode()", function() {
       beforeEach(function() {
         this.subject.treetable({
+          expandable: true,
           initialState: "collapsed"
         });
       });
@@ -262,6 +263,12 @@
       it("maintains chainability", function() {
         var row = $(this.subject[0].rows[0]);
         expect(this.subject.treetable("expandNode", row.data("ttId"))).to.equal(this.subject);
+      });
+
+      it("initializes nodes", function() {
+        var row = $(this.subject[0].rows[2]);
+        this.subject.treetable("expandNode", row.data("ttId"));
+        expect(this.subject.treetable("node", row.data("ttId")).initialized).to.be.true;
       });
     });
 
@@ -604,6 +611,12 @@
         expect(this.subject[3].row).to.be.hidden;
         this.subject[0].expand();
         expect(this.subject[3].row).to.be.visible;
+      });
+
+      it("does not show children if the node is hidden", function() {
+        expect(this.subject[3].row).to.be.hidden;
+        this.subject[2].expand();
+        expect(this.subject[3].row).to.be.hidden;
       });
 
       it("maintains chainability", function() {


### PR DESCRIPTION
This change allows hidden nodes to be set into an expanded state without their children becoming visible.  When the parent node of the expanded node is eventually expanded/shown it will automatically show the hidden expanded state.

I'm using the treetable in a control with an ajax based refresh button.  I track the expanded/collapsed state of all nodes and on refresh I want to put the tree back into the same expanded/collapsed state is was previously in.  Currently a user could expand a top level node, expand a second level node, then collapse the top level node; if the user re-expands the top level node the second level node will still be expanded as well.  If upon refresh the top level node is collapsed and the second level node is expanded, a call to expandNode on the second level node will set it to an expanded state and call _showChildren() which will cause the child nodes to display when they shouldn't.

This change calls _showChildren() from the expand() method only if the node is visible (i.e. does not have display: none).  It also initializes nodes when expandNode() is called.  This is to prevent the node from being recollapsed on initialization that normally occurs when the node is shown.
