### PR TITLE
Performance problem with rendering a treetable in an iframe (IE11)

### DIFF
--- a/jquery.treetable.js
+++ b/jquery.treetable.js
@@ -96,7 +96,7 @@
 
     Node.prototype.hide = function() {
       this._hideChildren();
-      this.row.hide();
+      this.row.css('display','none');
       return this;
     };
 


### PR DESCRIPTION
I came across this issue when testing a large collapsible treetable (over 2000 entries) rendered in an iframe in the IE11. The treetable renders ok in a standalone page (about 2 seconds) but in an IE11 iframe it took more than 50 seconds. After profiling the whole thing, the problem seemed to be related with jQuery hide method.
The change from .hide() to .css('display','none') fixed the performance issue.