### PR TITLE
Allow treetable for unsorted html

### DIFF
--- a/jquery.treetable.js
+++ b/jquery.treetable.js
@@ -295,6 +295,10 @@
             this.tree[node.id] = node;
 
             if (node.parentId != null && this.tree[node.parentId]) {
+              //Sort rows of DOM before initializing the tree to 
+				      //allows for unordered HTML to render correctly
+				      $(row).insertAfter("tr[data-tt-id='" + node.parentId + "']");
+              
               this.tree[node.parentId].addChild(node);
             } else {
               this.roots.push(node);


### PR DESCRIPTION
This PR changes the plugin to allow treetable to correctly initialize a table if the HTML is not sorted properly.