### PR TITLE
Allow treetable to prepend nodes instead of appending

### DIFF
--- a/jquery.treetable.js
+++ b/jquery.treetable.js
@@ -273,7 +273,15 @@
       }
       return _results;
     };
-
+	
+	Tree.prototype.findFirstNode = function (node) {
+      if (node.children.length > 0) {
+        return this.findLastNode(node.children[0]);
+      } else {
+        return node;
+      }
+    };
+	
     Tree.prototype.findLastNode = function (node) {
       if (node.children.length > 0) {
         return this.findLastNode(node.children[node.children.length - 1]);
@@ -442,7 +450,8 @@
         parentIdAttr: "ttParentId", // maps to data-tt-parent-id
         stringExpand: "Expand",
         stringCollapse: "Collapse",
-
+		prependRootNodes: false, // if true, prepend top level nodes instead of appending.
+		
         // Events
         onInitialized: null,
         onNodeCollapse: null,
@@ -512,7 +521,7 @@
       return this;
     },
 
-    loadBranch: function(node, rows) {
+    loadBranch: function(node, rows, prepend) {
       var settings = this.data("treetable").settings,
           tree = this.data("treetable").tree;
 
@@ -520,10 +529,18 @@
       rows = $(rows);
 
       if (node == null) { // Inserting new root nodes
-        this.append(rows);
+	    if(prepend || settings.prependRootNodes)
+			this.prepend(rows);
+		else
+			this.append(rows);
       } else {
-        var lastNode = this.data("treetable").findLastNode(node);
-        rows.insertAfter(lastNode.row);
+		  if(prepend){
+			var firstNode = this.data("treetable").findFirstNode(node);
+			rows.insertBefore(firstNode.row);
+		  } else {
+			var lastNode = this.data("treetable").findLastNode(node);
+			rows.insertAfter(lastNode.row);
+		  }
       }
 
       this.data("treetable").loadRows(rows);

--- a/jquery.treetable.js
+++ b/jquery.treetable.js
@@ -274,14 +274,6 @@
       return _results;
     };
 	
-	Tree.prototype.findFirstNode = function (node) {
-      if (node.children.length > 0) {
-        return this.findLastNode(node.children[0]);
-      } else {
-        return node;
-      }
-    };
-	
     Tree.prototype.findLastNode = function (node) {
       if (node.children.length > 0) {
         return this.findLastNode(node.children[node.children.length - 1]);
@@ -534,8 +526,9 @@
 		else
 			this.append(rows);
       } else {
-		  if(prepend){
-			var firstNode = this.data("treetable").findFirstNode(node);
+		  var hasChildNodes = node.children.length > 0;
+		  if(prepend && hasChildNodes){ // we can only prepend if there are childs
+			var firstNode = node.children[0];
 			rows.insertBefore(firstNode.row);
 		  } else {
 			var lastNode = this.data("treetable").findLastNode(node);


### PR DESCRIPTION
This PR aim to expand the feature of the treetable to allow it to prepend nodes on demand.

A new parameter prependRootNodes, by default false, added to the settings allow to set this behavior globally but only to root nodes (if needed I'll expand again to add a global param for this behavior on non root nodes).

A new parameter on the loadBranch function called prepend will allow to specifically request this current call to loadBranch to prepend nodes instead of appending them.

In any case it is still required from the user to provide the tr elements sorted if they pass several at once. It was not my intention to reverse the rows if multiples rows are passed at once.
For instance prepending:
``` 
-1.3
-1.4
-1.5
```
to:
```
1
-1.1
-1.2
```
with only one call to loadBranch will produce:
```
1
-1.3
-1.4
-1.5
-1.1
-1.2
```