### PR TITLE
Minor refactor: avoid some .data() overhead and remove a TODO

### DIFF
--- a/jquery.treetable.js
+++ b/jquery.treetable.js
@@ -517,7 +517,7 @@
       var settings = treetable.settings,
           tree = treetable.tree;
 
-      // TODO Switch to $.parseHTML
+      // do NOT switch to $.parseHTML in order to allow raw HTML as well as a jQuery object containing rows
       rows = $(rows);
 
       if (node == null) { // Inserting new root nodes

--- a/jquery.treetable.js
+++ b/jquery.treetable.js
@@ -513,8 +513,9 @@
     },
 
     loadBranch: function(node, rows) {
-      var settings = this.data("treetable").settings,
-          tree = this.data("treetable").tree;
+      var treetable = this.data("treetable");
+      var settings = treetable.settings,
+          tree = treetable.tree;
 
       // TODO Switch to $.parseHTML
       rows = $(rows);
@@ -522,11 +523,11 @@
       if (node == null) { // Inserting new root nodes
         this.append(rows);
       } else {
-        var lastNode = this.data("treetable").findLastNode(node);
+        var lastNode = treetable.findLastNode(node);
         rows.insertAfter(lastNode.row);
       }
 
-      this.data("treetable").loadRows(rows);
+      treetable.loadRows(rows);
 
       // Make sure nodes are properly initialized
       rows.filter("tr").each(function() {
@@ -542,11 +543,11 @@
     },
 
     move: function(nodeId, destinationId) {
-      var destination, node;
+      var destination, node, treetable = this.data("treetable");
 
-      node = this.data("treetable").tree[nodeId];
-      destination = this.data("treetable").tree[destinationId];
-      this.data("treetable").move(node, destination);
+      node = treetable.tree[nodeId];
+      destination = treetable.tree[destinationId];
+      treetable.move(node, destination);
 
       return this;
     },


### PR DESCRIPTION
Here you are two minor refactor:

* https://github.com/ludo/jquery-treetable/commit/f31d4c3c1567a554b0609a407946f3a3006bb117: In the methods `loadBranch` and `move` there were multiple calls to jQuery's `.data('treetable')`.
* https://github.com/ludo/jquery-treetable/commit/760fabee3a9273778aa28d02be9e5ecd4395a36e: The fact that now everything in the method `loadBranch` is encapsulated in a jQuery object allow to pass structures made using jQuery (e.g. `$( '<tr>' ).append ...` ) so it's a feature and it's a better approach over `$.parseHTML`.

Thank you!